### PR TITLE
fix: FormeerField.instances[key] initialization

### DIFF
--- a/src/instances.ts
+++ b/src/instances.ts
@@ -13,7 +13,7 @@ export class FormeerField<Value = any> {
         const key = `${formeerInstance.name}-${name}`;
 
         if (!FormeerField.instances[key]) {
-            FormeerField.instances[key] = new FormeerField<Value>(formeerInstance, name, options);
+            new FormeerField<Value>(formeerInstance, name, options);
         }
 
         return FormeerField.instances[key];
@@ -37,6 +37,9 @@ export class FormeerField<Value = any> {
 
     constructor(private formeerInstance: Formeer, fieldName: string, options: TFormeerFieldOptions<Value> = {}) {
         const { initialValue, validator } = options;
+
+        const key = `${formeerInstance.name}-${fieldName}`;
+        FormeerField.instances[key] = this;
 
         this.name = fieldName;
 


### PR DESCRIPTION
Проблема была не в errors$ как думал сначала, а в в instance.ts:16
Конструктор поля внутри себя обращался к FormeerField.instances[key]
constructor > Formeer.registerField > this.setFieldNames$.next
Далее асинхронный код - если у errors$ есть слушатели, то вызывался fieldNames$.pipe и внутри него было обращение к FormeerField.instances[key], которое еще не инициализировано так как не закончил работу первый конструктор

И так при добавлении одного поля конструктор мог рекурсивно вызваться 500-700 раз, до того как первый конструктор закончит работу и инициализирует поле FormeerField.instances[key]

Решил проблему переносом инициализации FormeerField.instances[key] в начало конструктора
